### PR TITLE
speedup fastcheckLevel()

### DIFF
--- a/log/trace.go
+++ b/log/trace.go
@@ -216,8 +216,5 @@ func ErrorTracef(ctx context.Context, things ...interface{}) (ok bool) {
 }
 
 func fastcheckLevel(level severity) bool {
-	if uint32(level) < atomic.LoadUint32(logLevel) {
-		return false
-	}
-	return true
+	return uint32(level) >= atomic.LoadUint32(logLevel)
 }


### PR DESCRIPTION
Is just a minor fix, but since I spotted it and the function is called fast*, I thought it is might worth doing the optimisation ...