### PR TITLE
Only set initial log level if flag is set

### DIFF
--- a/log/flags.go
+++ b/log/flags.go
@@ -8,6 +8,6 @@ var (
 )
 
 func init() {
-	flag.StringVar(&logLevelFlag, "log", "info", "set log level to [trace|debug|info|warning|error|critical]")
+	flag.StringVar(&logLevelFlag, "log", "", "set log level to [trace|debug|info|warning|error|critical]")
 	flag.StringVar(&pkgLogLevelsFlag, "plog", "", "set log level of packages: database=trace,notifications=debug")
 }

--- a/log/logging.go
+++ b/log/logging.go
@@ -137,12 +137,14 @@ func Start() (err error) {
 
 	logBuffer = make(chan *logLine, 1024)
 
-	initialLogLevel := ParseLevel(logLevelFlag)
-	if initialLogLevel > 0 {
+	if logLevelFlag != "" {
+		initialLogLevel := ParseLevel(logLevelFlag)
+		if initialLogLevel == 0 {
+			fmt.Fprintf(os.Stderr, "log warning: invalid log level \"%s\", falling back to level info\n", logLevelFlag)
+			initialLogLevel = InfoLevel
+		}
+
 		SetLogLevel(initialLogLevel)
-	} else {
-		err = fmt.Errorf("log warning: invalid log level \"%s\", falling back to level info", logLevelFlag)
-		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
 	}
 
 	// get and set file loglevels


### PR DESCRIPTION
This PR changes the `log` package to only set the default value if the flag is actually provided in the command line. It also fixes the fallback behavior if an invalid log level is given.