### PR TITLE
Fix validation error for floats

### DIFF
--- a/config/validate.go
+++ b/config/validate.go
@@ -70,7 +70,8 @@ func validateValue(option *Option, value interface{}) (*valueCache, error) { //n
 			return nil, fmt.Errorf("expected type %s for option %s, got type %T", getTypeName(option.OptType), option.Key, v)
 		}
 		if option.compiledRegex != nil {
-			if !option.compiledRegex.MatchString(fmt.Sprintf("%d", v)) {
+			// we need to use %v here so we handle float and int correctly.
+			if !option.compiledRegex.MatchString(fmt.Sprintf("%v", v)) {
 				return nil, fmt.Errorf("validation of option %s failed: number \"%d\" did not match validation regex", option.Key, v)
 			}
 		}


### PR DESCRIPTION
When loading a persisted configuration from a JSON file the `config` module fails when loading a `OptTypeInt` or `OptTypeFloat` option because the validation regex is applied to the string representation created by `%d`. Since JSON always decods as float64 the validation fails because the result is `%!d(float64=7)`.