### PR TITLE
Make DB registry persistence optional

### DIFF
--- a/database/location.go
+++ b/database/location.go
@@ -1,1 +1,0 @@
-package database

--- a/database/main.go
+++ b/database/main.go
@@ -40,13 +40,12 @@ func Initialize(dirStructureRoot *utils.DirStructure) error {
 			return fmt.Errorf("could not create/open database directory (%s): %s", rootStructure.Path, err)
 		}
 
-		err = loadRegistry()
-		if err != nil {
-			return fmt.Errorf("could not load database registry (%s): %s", filepath.Join(rootStructure.Path, registryFileName), err)
+		if registryPersistence.IsSet() {
+			err = loadRegistry()
+			if err != nil {
+				return fmt.Errorf("could not load database registry (%s): %s", filepath.Join(rootStructure.Path, registryFileName), err)
+			}
 		}
-
-		// start registry writer
-		go registryWriter()
 
 		return nil
 	}


### PR DESCRIPTION
This increases resilience when persistence is not needed.

Background: Portmaster refused to start once because the databases.json file was empty.