### PR TITLE
Remove exclusiveAccess lock from database controller

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -1,7 +1,6 @@
 package database
 
 import (
-	"errors"
 	"time"
 )
 
@@ -14,11 +13,6 @@ type Database struct {
 	Registered   time.Time
 	LastUpdated  time.Time
 	LastLoaded   time.Time
-}
-
-// MigrateTo migrates the database to another storage type.
-func (db *Database) MigrateTo(newStorageType string) error {
-	return errors.New("not implemented yet") // TODO
 }
 
 // Loaded updates the LastLoaded timestamp.

--- a/database/hook.go
+++ b/database/hook.go
@@ -5,15 +5,36 @@ import (
 	"github.com/safing/portbase/database/record"
 )
 
-// Hook describes a hook
+// Hook can be registered for a database query and
+// will be executed at certain points during the life
+// cycle of a database record.
 type Hook interface {
+	// UsesPreGet should return true if the hook's PreGet
+	// should be called prior to loading a database record
+	// from the underlying storage.
 	UsesPreGet() bool
+	// PreGet is called before a database record is loaded from
+	// the underlying storage. A PreGet hookd may be used to
+	// implement more advanced access control on database keys.
 	PreGet(dbKey string) error
-
+	// UsesPostGet should returnd true if the hook's PostGet
+	// should be called after loading a database record from
+	// the underlying storage.
 	UsesPostGet() bool
+	// PostGet is called after a record has been loaded form the
+	// underlying storage and may perform additional mutation
+	// or access check based on the records data.
+	// The passed record is already locked by the database system
+	// so users can safely access all data of r.
 	PostGet(r record.Record) (record.Record, error)
-
+	// UsesPrePut should return true if the hook's PrePut method
+	// should be called prior to saving a record in the database.
 	UsesPrePut() bool
+	// PrePut is called prior to saving (creating or updating) a
+	// record in the database storage. It may be used to perform
+	// extended validation or mutations on the record.
+	// The passed record is already locked by the database system
+	// so users can safely access all data of r.
 	PrePut(r record.Record) (record.Record, error)
 }
 
@@ -23,7 +44,8 @@ type RegisteredHook struct {
 	h Hook
 }
 
-// RegisterHook registers a hook for records matching the given query in the database.
+// RegisterHook registers a hook for records matching the given
+// query in the database.
 func RegisterHook(q *query.Query, hook Hook) (*RegisteredHook, error) {
 	_, err := q.Check()
 	if err != nil {
@@ -35,26 +57,29 @@ func RegisterHook(q *query.Query, hook Hook) (*RegisteredHook, error) {
 		return nil, err
 	}
 
-	c.exclusiveAccess.Lock()
-	defer c.exclusiveAccess.Unlock()
-
 	rh := &RegisteredHook{
 		q: q,
 		h: hook,
 	}
+
+	c.hooksLock.Lock()
+	defer c.hooksLock.Unlock()
 	c.hooks = append(c.hooks, rh)
+
 	return rh, nil
 }
 
-// Cancel unhooks the hook.
+// Cancel unregisteres the hook from the database. Once
+// Cancel returned the hook's methods will not be called
+// anymore for updates that matched the registered query.
 func (h *RegisteredHook) Cancel() error {
 	c, err := getController(h.q.DatabaseName())
 	if err != nil {
 		return err
 	}
 
-	c.exclusiveAccess.Lock()
-	defer c.exclusiveAccess.Unlock()
+	c.hooksLock.Lock()
+	defer c.hooksLock.Unlock()
 
 	for key, hook := range c.hooks {
 		if hook.q == h.q {

--- a/database/subscription.go
+++ b/database/subscription.go
@@ -10,7 +10,6 @@ type Subscription struct {
 	q        *query.Query
 	local    bool
 	internal bool
-	canceled bool
 
 	Feed chan record.Record
 }
@@ -22,18 +21,13 @@ func (s *Subscription) Cancel() error {
 		return err
 	}
 
-	c.exclusiveAccess.Lock()
-	defer c.exclusiveAccess.Unlock()
-
-	if s.canceled {
-		return nil
-	}
-	s.canceled = true
-	close(s.Feed)
+	c.subscriptionLock.Lock()
+	defer c.subscriptionLock.Unlock()
 
 	for key, sub := range c.subscriptions {
 		if sub.q == s.q {
 			c.subscriptions = append(c.subscriptions[:key], c.subscriptions[key+1:]...)
+			close(s.Feed) // this close is guarded by the controllers subscriptionLock.
 			return nil
 		}
 	}


### PR DESCRIPTION
This PR removes the `exclusiveAccess` rw-mutex from the database controller as it might cause deadlocks in certain situations and is not required anymore.