### PR TITLE
Fix metrics, modules, api

### DIFF
--- a/api/authentication.go
+++ b/api/authentication.go
@@ -151,7 +151,7 @@ func authenticateRequest(w http.ResponseWriter, r *http.Request, targetHandler h
 	switch requiredPermission { //nolint:exhaustive
 	case NotFound:
 		// Not found.
-		tracer.Trace("api: authenticated handler reported: not found")
+		tracer.Debug("api: no API endpoint registered for this path")
 		http.Error(w, "Not found.", http.StatusNotFound)
 		return nil
 	case NotSupported:

--- a/api/router.go
+++ b/api/router.go
@@ -235,6 +235,7 @@ func (mh *mainHandler) handle(w http.ResponseWriter, r *http.Request) error {
 		http.Error(lrw, "Method not allowed.", http.StatusMethodNotAllowed)
 		return nil
 	default:
+		tracer.Debug("api: no handler registered for this path")
 		http.Error(lrw, "Not found.", http.StatusNotFound)
 		return nil
 	}

--- a/metrics/api.go
+++ b/metrics/api.go
@@ -11,7 +11,6 @@ import (
 	"github.com/safing/portbase/api"
 	"github.com/safing/portbase/config"
 	"github.com/safing/portbase/log"
-	"github.com/safing/portbase/utils"
 )
 
 func registerAPI() error {
@@ -140,11 +139,7 @@ func writeMetricsTo(ctx context.Context, url string) error {
 	)
 }
 
-var metricsPusherDone = utils.NewBroadcastFlag()
-
 func metricsWriter(ctx context.Context) error {
-	defer metricsPusherDone.NotifyAndReset()
-
 	pushURL := pushOption()
 	ticker := module.NewSleepyTicker(1*time.Minute, 0)
 	defer ticker.Stop()

--- a/metrics/metrics_host.go
+++ b/metrics/metrics_host.go
@@ -16,7 +16,7 @@ import (
 
 const hostStatTTL = 1 * time.Second
 
-func registeHostMetrics() (err error) {
+func registerHostMetrics() (err error) {
 	// Register load average metrics.
 	_, err = NewGauge("host/load/avg/1", nil, getFloat64HostStat(LoadAvg1), &Options{Name: "Host Load Avg 1min", Permission: api.PermitUser})
 	if err != nil {

--- a/metrics/metrics_info.go
+++ b/metrics/metrics_info.go
@@ -3,9 +3,12 @@ package metrics
 import (
 	"runtime"
 	"strings"
+	"sync/atomic"
 
 	"github.com/safing/portbase/info"
 )
+
+var reportedStart atomic.Bool
 
 func registerInfoMetric() error {
 	meta := info.GetInfo()
@@ -26,6 +29,10 @@ func registerInfoMetric() error {
 			"comment":       commentOption(),
 		},
 		func() float64 {
+			// Report as 0 the first time in order to detect (re)starts.
+			if reportedStart.CompareAndSwap(false, true) {
+				return 0
+			}
 			return 1
 		},
 		nil,

--- a/metrics/metrics_logs.go
+++ b/metrics/metrics_logs.go
@@ -5,7 +5,7 @@ import (
 	"github.com/safing/portbase/log"
 )
 
-func registeLogMetrics() (err error) {
+func registerLogMetrics() (err error) {
 	_, err = NewFetchingCounter(
 		"logs/warning/total",
 		nil,

--- a/metrics/module.go
+++ b/metrics/module.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/safing/portbase/log"
 	"github.com/safing/portbase/modules"
 )
 
@@ -36,7 +35,7 @@ var (
 )
 
 func init() {
-	module = modules.Register("metrics", prep, start, stop, "config", "database", "api", "base")
+	module = modules.Register("metrics", prep, start, stop, "config", "database", "api")
 }
 
 func prep() error {
@@ -69,10 +68,6 @@ func start() error {
 
 	if err := registerAPI(); err != nil {
 		return err
-	}
-
-	if err := loadPersistentMetrics(); err != nil {
-		log.Errorf("metrics: failed to load persistent metrics: %s", err)
 	}
 
 	if pushOption() != "" {
@@ -120,6 +115,10 @@ func register(m Metric) error {
 
 	// Set flag that first metric is now registered.
 	firstMetricRegistered = true
+
+	if module.Status() < modules.StatusStarting {
+		return fmt.Errorf("registering metric %q too early", m.ID())
+	}
 
 	return nil
 }

--- a/metrics/persistence.go
+++ b/metrics/persistence.go
@@ -52,10 +52,18 @@ func EnableMetricPersistence(key string) error {
 
 	// Set storage key.
 	storageKey = key
+	return nil
+}
+
+func loadPersistentMetrics() error {
+	// Abort if storage is not enabled.
+	if storageInit.SetToIf(false, true) {
+		return nil
+	}
 
 	// Load metrics from storage.
 	var err error
-	storage, err = getMetricsStorage(key)
+	storage, err = getMetricsStorage(storageKey)
 	switch {
 	case err == nil:
 		// Continue.

--- a/metrics/persistence.go
+++ b/metrics/persistence.go
@@ -25,7 +25,7 @@ var (
 	})
 
 	// ErrAlreadyInitialized is returned when trying to initialize an option
-	// more than once.
+	// more than once or if the time window for initializing is over.
 	ErrAlreadyInitialized = errors.New("already initialized")
 )
 
@@ -52,14 +52,6 @@ func EnableMetricPersistence(key string) error {
 
 	// Set storage key.
 	storageKey = key
-	return nil
-}
-
-func loadPersistentMetrics() error {
-	// Abort if storage is not enabled.
-	if storageInit.SetToIf(false, true) {
-		return nil
-	}
 
 	// Load metrics from storage.
 	var err error


### PR DESCRIPTION
- Fix waiting for log writers on shutdown, improve persistence enabling
- Report info metric as 0 the first time to track when software is (re)started
- Improve api logging when handler/endpoint does not exist
- Improve handling of service worker errors
- Improve stopping of modules
- Fix enabling metric persistence
